### PR TITLE
Add option to build with a LLVM prefix or LLVM with suffix instead of system LLVM/in-tree LLVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To build GNAT LLVM from sources, follow these steps:
   `LLVM_CONFIG` pointing to your `llvm-config` binary, this way the LLVM you
   intend to use does not need to be in your `PATH`.
 
-      LLVM_CONFIG=/some/path/to/llvm-config make
+      make LLVM_CONFIG=/some/path/to/llvm-config
 
   An alternative only suitable for core GNAT LLVM development on x86 native
   configurations is to use the following command, assuming you have CMake

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ To build GNAT LLVM from sources, follow these steps:
   the options that suit your needs. After installing/building, make sure the
   LLVM bin directory containing `llvm-config` and `clang` is in your `PATH`.
 
+  Alternatively, you can invoke make with an environment variable named 
+  `LLVM_CONFIG` pointing to your `llvm-config` binary, this way the LLVM you
+  intend to use does not need to be in your `PATH`.
+
+      LLVM_CONFIG=/some/path/to/llvm-config make
+
   An alternative only suitable for core GNAT LLVM development on x86 native
   configurations is to use the following command, assuming you have CMake
   version >= 3.20 in your path:

--- a/llvm-interface/Makefile
+++ b/llvm-interface/Makefile
@@ -25,7 +25,7 @@ ifeq ($(LLVM_CONFIG),)
 else
   LLVM_CONFIG:=$(LLVM_CONFIG)
 endif
-CLANG_CXXFLAGS=-I$(shell $(LLVM_CONFIG) --prefix)/tools/clang/include -I$(shell cd `$(LLVM_CONFIG) --includedir`/../..;pwd)/clang/include
+CLANG_CXXFLAGS=-I$(shell `$(LLVM_CONFIG) --includedir`)/clang
 
 LDFLAGS=$(shell $(LLVM_CONFIG) --libs all --ldflags --system-libs)
 CXXFLAGS=

--- a/llvm-interface/Makefile
+++ b/llvm-interface/Makefile
@@ -28,8 +28,20 @@ ifneq ($(wildcard $(LLVM_BUILD_DIR)/bin/llvm-config),)
   LLVM_SRC=$(shell cd `$(LLVM_CONFIG) --includedir`/../..;pwd)
   CLANG_CXXFLAGS=-I$(LLVM_BUILD_DIR)/tools/clang/include -I$(LLVM_SRC)/clang/include
 else
-  LLVM_CONFIG=llvm-config
-  CLANG_CXXFLAGS=
+	# Allows the use of alternate named binaries
+	ifneq ($(LLVM_CONFIG),)
+		LLVM_CONFIG:=$(LLVM_CONFIG)
+	else
+		LLVM_CONFIG=llvm-config
+	endif
+	
+	# Allows the use of a custom LLVM prefix
+	ifneq ($(LLVM_PREFIX),)
+		LLVM_CONFIG:=$(LLVM_PREFIX)/$(LLVM_CONFIG)
+		CLANG_CXXFLAGS=-I$(shell $(LLVM_CONFIG) --prefix)/tools/clang/include -I$(shell cd `$(LLVM_CONFIG) --prefix`/..;pwd)/clang/include
+	else
+		CLANG_CXXFLAGS=
+	endif
 endif
 
 LDFLAGS=$(shell $(LLVM_CONFIG) --libs all --ldflags --system-libs)

--- a/llvm-interface/Makefile
+++ b/llvm-interface/Makefile
@@ -20,29 +20,12 @@ ADAINCLUDE=lib/rts-llvm/adainclude
 ADALIB=lib/rts-llvm/adalib
 
 pwd:=$(shell pwd)
-
-LLVM_BUILD_DIR=$(pwd)/../llvm/llvm-obj
-
-ifneq ($(wildcard $(LLVM_BUILD_DIR)/bin/llvm-config),)
-  LLVM_CONFIG=$(LLVM_BUILD_DIR)/bin/llvm-config
-  LLVM_SRC=$(shell cd `$(LLVM_CONFIG) --includedir`/../..;pwd)
-  CLANG_CXXFLAGS=-I$(LLVM_BUILD_DIR)/tools/clang/include -I$(LLVM_SRC)/clang/include
+ifeq ($(LLVM_CONFIG),)
+  LLVM_CONFIG:=llvm-config
 else
-	# Allows the use of alternate named binaries
-	ifneq ($(LLVM_CONFIG),)
-		LLVM_CONFIG:=$(LLVM_CONFIG)
-	else
-		LLVM_CONFIG=llvm-config
-	endif
-	
-	# Allows the use of a custom LLVM prefix
-	ifneq ($(LLVM_PREFIX),)
-		LLVM_CONFIG:=$(LLVM_PREFIX)/$(LLVM_CONFIG)
-		CLANG_CXXFLAGS=-I$(shell $(LLVM_CONFIG) --prefix)/tools/clang/include -I$(shell cd `$(LLVM_CONFIG) --prefix`/..;pwd)/clang/include
-	else
-		CLANG_CXXFLAGS=
-	endif
+  LLVM_CONFIG:=$(LLVM_CONFIG)
 endif
+CLANG_CXXFLAGS=-I$(shell $(LLVM_CONFIG) --prefix)/tools/clang/include -I$(shell cd `$(LLVM_CONFIG) --includedir`/../..;pwd)/clang/include
 
 LDFLAGS=$(shell $(LLVM_CONFIG) --libs all --ldflags --system-libs)
 CXXFLAGS=

--- a/llvm-interface/check_for_LLVM_aliasing_bug.sh
+++ b/llvm-interface/check_for_LLVM_aliasing_bug.sh
@@ -110,8 +110,8 @@ declare i32 @report__ident_int(i32)
 !24 = !{!10, !13, i64 4, i64 4}
 
 EOF
-opt -O2 obj/c43204h.ll -o obj/c43204h_o.bc
-llvm-dis obj/c43204h_o.bc
+$("$LLVM_CONFIG" --bindir)/opt -O2 obj/c43204h.ll -o obj/c43204h_o.bc
+$("$LLVM_CONFIG" --bindir)/llvm-dis obj/c43204h_o.bc
 if [ "`wc -l obj/c43204h_o.ll | awk '{print $1}'` " -gt "40" ]; then
     BUG=False
     echo "OK: using LLVM without the aliasing bug"


### PR DESCRIPTION
This patch allows the use of a LLVM prefix instead of system or built in-tree LLVM, this is part of the effort to distribute gnat-llvm in alire.